### PR TITLE
introduced IMetricReporter interface

### DIFF
--- a/lib/metrics/metric.ts
+++ b/lib/metrics/metric.ts
@@ -179,8 +179,23 @@ export abstract class BaseMetric implements Metric {
         return this;
     }
 
+    public setTags(tags: Map<string, string>): this {
+        this.tags = tags;
+        return this;
+    }
+
+    public addTags(tags: Map<string, string>): this {
+        tags.forEach((value, key) => this.tags.set(key, value));
+        return this;
+    }
+
     public removeTag(name: string): this {
         this.tags.delete(name);
+        return this;
+    }
+
+    public removeTags(...names: string[]): this {
+        names.forEach((name) => this.removeTag(name));
         return this;
     }
 

--- a/lib/metrics/reporter/metric-reporter.ts
+++ b/lib/metrics/reporter/metric-reporter.ts
@@ -119,13 +119,100 @@ export interface MetricReporterOptions {
 }
 
 /**
+ * Interface for metric-reporter.
+ *
+ * @export
+ * @interface IMetricReporter
+ */
+export interface IMetricReporter {
+    /**
+     * Gets the reporter tags.
+     *
+     * @returns {Map<string, string>}
+     * @memberof IMetricReporter
+     */
+    getTags(): Map<string, string>;
+
+    /**
+     * Sets the reporter tags.
+     *
+     * @param {Map<string, string>} tags
+     * @returns {this}
+     * @memberof IMetricReporter
+     */
+    setTags(tags: Map<string, string>): this;
+
+    /**
+     * Implementations start reporting metrics when called.
+     *
+     * @abstract
+     * @returns {this}
+     * @memberof IMetricReporter
+     */
+    start(): this;
+
+    /**
+     * Implementations stop reporting metrics when called.
+     *
+     * @abstract
+     * @returns {this}
+     * @memberof IMetricReporter
+     */
+    stop(): this;
+
+    /**
+     * Adds a new {@link MetricRegistry} to be reported.
+     *
+     * @param {MetricRegistry} metricRegistry
+     * @returns {this}
+     * @memberof IMetricReporter
+     */
+    addMetricRegistry(metricRegistry: MetricRegistry): this;
+
+    /**
+     * Removes the given {@link MetricRegistry} if it was previously added.
+     *
+     * @param {MetricRegistry} metricRegistry
+     * @returns {this}
+     * @memberof IMetricReporter
+     */
+    removeMetricRegistry(metricRegistry: MetricRegistry): this;
+
+    /**
+     * Reports an {@link Event}.
+     *
+     * Implementations can choose how to process ad-hoc events, wether it's
+     * queuing the events to the next call to report or sending events
+     * immediately.
+     *
+     * Also the usual reporting process of calling {@link #beforeReport}, do the reporting
+     * and call {@link #afterReport} may not be applied for ad-hoc events.
+     *
+     * This implementation does nothing and always resolved the specified evnet.
+     *
+     * @param {MetricRegistry} event
+     * @returns {ThisType}
+     * @memberof IMetricReporter
+     */
+    reportEvent<TEventData, TEvent extends Event<TEventData>>(event: TEvent): Promise<TEvent>;
+
+    /**
+     * Sends events remaining in the queue (if a queue is used in the implementation).
+     *
+     * @returns {Promise<void>}
+     * @memberof IMetricReporter
+     */
+    flushEvents(): Promise<void>;
+}
+
+/**
  * Base-class for metric-reporter implementations.
  *
  * @export
  * @abstract
  * @class MetricReporter
  */
-export abstract class MetricReporter<O extends MetricReporterOptions, T> {
+export abstract class MetricReporter<O extends MetricReporterOptions, T> implements IMetricReporter {
 
     /**
      * {@link MetricRegistry} instances.

--- a/lib/metrics/taggable.ts
+++ b/lib/metrics/taggable.ts
@@ -36,6 +36,24 @@ export interface Taggable {
     setTag(name: string, value: string): this;
 
     /**
+     * Sets tags set.
+     *
+     * @param {Map<string, string>} name
+     * @returns {this}
+     * @memberof Taggable
+     */
+    setTags(tags: Map<string, string>): this;
+
+    /**
+     * Adds tags to the tags set.
+     *
+     * @param {Map<string, string>} name
+     * @returns {this}
+     * @memberof Taggable
+     */
+    addTags(tags: Map<string, string>): this;
+
+    /**
      * Removes the specified tag.
      *
      * @param {string} name
@@ -43,5 +61,14 @@ export interface Taggable {
      * @memberof Taggable
      */
     removeTag(name: string): this;
+
+    /**
+     * Removes the specified tag.
+     *
+     * @param {string[]} names
+     * @returns {this}
+     * @memberof Taggable
+     */
+    removeTags(...names: string[]): this;
 
 }


### PR DESCRIPTION
I introduced IMetricReporter interface so that users can manipulate the interface rather than the implementation itself.

This can be helpful as implementations are generics and somewhat difficult to use as abstractions directly.