### PR TITLE
Fix bug: LoggerReporter.reportGauge returning null if 'gauge.value' i…

### DIFF
--- a/lib/metrics/reporter/logger-reporter.ts
+++ b/lib/metrics/reporter/logger-reporter.ts
@@ -258,7 +258,7 @@ export class LoggerReporter extends ScheduledMetricReporter<LoggerReporterOption
      * @memberof LoggerReporter
      */
     protected reportGauge(gauge: Gauge<any>, ctx: LoggerReportingContext<Gauge<any>>): LogLine {
-        if (!isNaN(gauge.getValue())) {
+        if (!Number.isNaN(gauge.getValue())) {
             const name = gauge.getName();
             ctx.logMetadata.measurement = name;
             ctx.logMetadata.group = gauge.getGroup();


### PR DESCRIPTION
The LoggerReporter.reportGauge (hence reportEvent) method does not log anything if the 'value' property of the gauge (or the event) is not a number. I was trying to report an Event when I came across this problem.
I'm working with @doubret :-) .